### PR TITLE
OAK-2829 : querying external changes in chunks, use external sort whe…

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
@@ -590,7 +590,7 @@ public class Commit {
             }
             list.add(p);
         }
-        DiffCache.Entry cacheEntry = nodeStore.getDiffCache().newEntry(before, revision);
+        DiffCache.Entry cacheEntry = nodeStore.getDiffCache().newEntry(before, revision, true);
         LastRevTracker tracker = nodeStore.createTracker(revision, isBranchCommit);
         List<String> added = new ArrayList<String>();
         List<String> removed = new ArrayList<String>();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DiffCache.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DiffCache.java
@@ -56,11 +56,14 @@ public interface DiffCache {
      *
      * @param from the from revision.
      * @param to the to revision.
+     * @param local true indicates that the entry results from a local change,
+     * false if it results from an external change
      * @return the cache entry.
      */
     @Nonnull
     Entry newEntry(@Nonnull Revision from,
-                   @Nonnull Revision to);
+                   @Nonnull Revision to,
+                   boolean local);
 
     /**
      * @return the statistics for this cache.

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -369,6 +369,8 @@ public final class DocumentNodeStore
 
     private final VersionGarbageCollector versionGarbageCollector;
 
+    private final JournalGarbageCollector journalGarbageCollector;
+    
     private final Executor executor;
 
     private final LastRevRecoveryAgent lastRevRecoveryAgent;
@@ -412,6 +414,7 @@ public final class DocumentNodeStore
         this.asyncDelay = builder.getAsyncDelay();
         this.versionGarbageCollector = new VersionGarbageCollector(
                 this, builder.createVersionGCSupport());
+        this.journalGarbageCollector = new JournalGarbageCollector(this);
         this.lastRevRecoveryAgent = new LastRevRecoveryAgent(this);
         this.disableBranches = builder.isDisableBranches();
         this.missing = new DocumentNodeState(this, "MISSING", new Revision(0, 0, 0)) {
@@ -2583,6 +2586,12 @@ public final class DocumentNodeStore
     public VersionGarbageCollector getVersionGarbageCollector() {
         return versionGarbageCollector;
     }
+
+    @Nonnull
+    public JournalGarbageCollector getJournalGarbageCollector() {
+        return journalGarbageCollector;
+    }
+    
     @Nonnull
     public LastRevRecoveryAgent getLastRevRecoveryAgent() {
         return lastRevRecoveryAgent;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -625,11 +625,7 @@ public class DocumentNodeStoreService {
 
             @Override
             public void run() {
-                try {
-                    nodeStore.getJournalGarbageCollector().gc(journalGCMaxAge, TimeUnit.MILLISECONDS);
-                } catch (IOException e) {
-                    log.error("run: could not successfully finish JournalGC, IOException thrown: "+e, e);
-                }
+                nodeStore.getJournalGarbageCollector().gc(journalGCMaxAge, TimeUnit.MILLISECONDS);
             }
 
         };

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -27,6 +27,7 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentMK.Builder.DEFA
 import static org.apache.jackrabbit.oak.plugins.document.DocumentMK.Builder.DEFAULT_DOC_CHILDREN_CACHE_PERCENTAGE;
 import static org.apache.jackrabbit.oak.plugins.document.DocumentMK.Builder.DEFAULT_NODE_CACHE_PERCENTAGE;
 import static org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils.registerMBean;
+import static org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils.scheduleWithFixedDelay;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -44,6 +45,7 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
+
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -191,6 +193,23 @@ public class DocumentNodeStoreService {
     )
     public static final String CUSTOM_BLOB_STORE = "customBlobStore";
 
+    private static final long DEFAULT_JOURNAL_GC_INTERVAL_MILLIS = 5*60*1000; // default is 5min
+    @Property(longValue = DEFAULT_JOURNAL_GC_INTERVAL_MILLIS,
+            label = "Journal Garbage Collection Interval (millis)",
+            description = "Long value indicating interval (in milliseconds) with which the "
+                    + "journal (for external changes) is cleaned up. Default is " + DEFAULT_JOURNAL_GC_INTERVAL_MILLIS
+    )
+    private static final String PROP_JOURNAL_GC_INTERVAL_MILLIS = "journalGCInterval";
+    
+    private static final long DEFAULT_JOURNAL_GC_MAX_AGE_MILLIS = 6*60*60*1000; // default is 6hours
+    @Property(longValue = DEFAULT_JOURNAL_GC_MAX_AGE_MILLIS,
+            label = "Maximum Age of Journal Entries (millis)",
+            description = "Long value indicating max age (in milliseconds) that "
+                    + "journal (for external changes) entries are kept (older ones are candidates for gc). "
+                    + "Default is " + DEFAULT_JOURNAL_GC_MAX_AGE_MILLIS
+    )
+    private static final String PROP_JOURNAL_GC_MAX_AGE_MILLIS = "journalGCMaxAge";
+    
     /**
      * Boolean value indicating a different DataSource has to be used for
      * BlobStore
@@ -410,6 +429,7 @@ public class DocumentNodeStoreService {
 
         registerJMXBeans(mk.getNodeStore());
         registerLastRevRecoveryJob(mk.getNodeStore());
+        registerJournalGC(mk.getNodeStore());
 
         NodeStore store;
         DocumentNodeStore mns = mk.getNodeStore();
@@ -594,6 +614,27 @@ public class DocumentNodeStoreService {
         };
         registrations.add(WhiteboardUtils.scheduleWithFixedDelay(whiteboard,
                 recoverJob, TimeUnit.MILLISECONDS.toSeconds(leaseTime)));
+    }
+
+    private void registerJournalGC(final DocumentNodeStore nodeStore) {
+        long journalGCInterval = toLong(context.getProperties().get(PROP_JOURNAL_GC_INTERVAL_MILLIS),
+                DEFAULT_JOURNAL_GC_INTERVAL_MILLIS);
+        final long journalGCMaxAge = toLong(context.getProperties().get(PROP_JOURNAL_GC_MAX_AGE_MILLIS),
+                DEFAULT_JOURNAL_GC_MAX_AGE_MILLIS);
+        Runnable journalGCJob = new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    nodeStore.getJournalGarbageCollector().gc(journalGCMaxAge, TimeUnit.MILLISECONDS);
+                } catch (IOException e) {
+                    log.error("run: could not successfully finish JournalGC, IOException thrown: "+e, e);
+                }
+            }
+
+        };
+        registrations.add(WhiteboardUtils.scheduleWithFixedDelay(whiteboard,
+                journalGCJob, TimeUnit.MILLISECONDS.toSeconds(journalGCInterval), true/*runOnSingleClusterNode*/));
     }
 
     private Object prop(String propName) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
@@ -60,12 +60,12 @@ import static org.apache.jackrabbit.oak.plugins.document.Collection.JOURNAL;
  *      Push changes to {@link MemoryDiffCache} instead of {@link LocalDiffCache}.
  *      See {@link TieredDiffCache#newEntry(Revision, Revision)}. Maybe a new
  *      method is needed for this purpose?
- * Done: manually tested, automated tests to be done however!
+ * Done (incl junit) 
  *      Create JournalEntry for external changes related to _lastRev recovery.
  *      See {@link LastRevRecoveryAgent#recover(Iterator, int, boolean)}.
- * Done: manually tested, automated tests to be done however!
+ * Done (incl junit)
  *      Cleanup old journal entries in the document store.
- * TODO:
+ * Done:
  *      integrate the JournalGarbageCollector similarly to the VersionGarbageCollector
  */
 public final class JournalEntry extends Document {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
@@ -16,6 +16,9 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
+
+import java.io.IOException;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +36,8 @@ import org.apache.jackrabbit.oak.commons.json.JsopReader;
 import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
 import org.apache.jackrabbit.oak.commons.sort.StringSort;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -42,26 +47,30 @@ import static org.apache.jackrabbit.oak.plugins.document.Collection.JOURNAL;
 /**
  * Keeps track of changes performed between two consecutive background updates.
  *
- * TODO:
+ * Done:
  *      Query external changes in chunks.
  *      {@link #getChanges(Revision, Revision, DocumentStore)} current reads
  *      all JournalEntry documents in one go with a limit of Integer.MAX_VALUE.
- * TODO:
+ * Done:
  *      Use external sort when changes are applied to diffCache. See usage of
  *      {@link #applyTo(DiffCache, Revision, Revision)} in
  *      {@link DocumentNodeStore#backgroundRead(boolean)}.
  *      The utility {@link StringSort} can be used for this purpose.
- * TODO:
+ * Done:
  *      Push changes to {@link MemoryDiffCache} instead of {@link LocalDiffCache}.
  *      See {@link TieredDiffCache#newEntry(Revision, Revision)}. Maybe a new
  *      method is needed for this purpose?
- * TODO:
+ * Done: manually tested, automated tests to be done however!
  *      Create JournalEntry for external changes related to _lastRev recovery.
  *      See {@link LastRevRecoveryAgent#recover(Iterator, int, boolean)}.
- * TODO:
+ * Done: manually tested, automated tests to be done however!
  *      Cleanup old journal entries in the document store.
+ * TODO:
+ *      integrate the JournalGarbageCollector similarly to the VersionGarbageCollector
  */
 public final class JournalEntry extends Document {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JournalEntry.class);
 
     /**
      * The revision format for external changes:
@@ -76,6 +85,10 @@ public final class JournalEntry extends Document {
 
     private static final String BRANCH_COMMITS = "_bc";
 
+    private static final int READ_CHUNK_SIZE = 1024;
+    
+    private static final int STRINGSORT_OVERFLOW_TO_DISK_THRESHOLD = 1024 * 1024; // switch to disk after 1MB
+    
     private final DocumentStore store;
 
     private volatile TreeNode changes = null;
@@ -83,31 +96,143 @@ public final class JournalEntry extends Document {
     JournalEntry(DocumentStore store) {
         this.store = store;
     }
+    
+    static StringSort newSorter() {
+        return new StringSort(STRINGSORT_OVERFLOW_TO_DISK_THRESHOLD, new Comparator<String>() {
+            @Override
+            public int compare(String arg0, String arg1) {
+                return arg0.compareTo(arg1);
+            }
+        });
+    }
+	
+    static void applyTo(@Nonnull StringSort externalSort,
+    				    @Nonnull DiffCache diffCache,
+    				    @Nonnull Revision from,
+    				    @Nonnull Revision to) throws IOException {
+        LOG.debug("applyTo: starting for {} to {}", from, to);
+		externalSort.sort();
+		// note that it is not deduplicated yet
+		LOG.debug("applyTo: sorting done.");
+		
+		final DiffCache.Entry entry = checkNotNull(diffCache).newEntry(from, to, false);
 
+		final Iterator<String> it = externalSort.getIds();
+		if (!it.hasNext()) {
+			// nothing at all? that's quite unusual..
+			
+			// we apply this diff as one '/' to the entry then
+		    entry.append("/", "");
+			entry.done();
+			return;
+		}
+		String previousPath = it.next();
+		TreeNode node = new TreeNode(null, "");
+		node = node.getOrCreatePath(previousPath); 
+		int totalCnt = 0;
+		int deDuplicatedCnt = 0;
+		while(it.hasNext()) {
+			totalCnt++;
+			final String currentPath = it.next();
+			if (previousPath.equals(currentPath)) {
+				// de-duplication
+				continue;
+			}
+			
+			// 'node' contains one hierarchy line, eg /a, /a/b, /a/b/c, /a/b/c/d
+			// including the children on each level.
+			// these children have not yet been appended to the diffCache entry
+			// and have to be added as soon as the 'currentPath' is not
+			// part of that hierarchy anymore and we 'move elsewhere'.
+			// eg if 'currentPath' is /a/b/e, then we must flush /a/b/c/d and /a/b/c
+			while(node!=null && !node.isParentOf(currentPath)) {
+				// add parent to the diff entry
+			    entry.append(node.getPath(), getChanges(node));
+				deDuplicatedCnt++;
+				node = node.parent;
+			}
+			
+			if (node==null) {
+			    // we should never go 'passed' the root, hence node should 
+			    // never be null - if it becomes null anyway, start with
+			    // a fresh root:
+			    node = new TreeNode(null, "");
+	            node = node.getOrCreatePath(currentPath);
+			} else {
+			    // this is the normal route: we add a direct or grand-child
+			    // node to the current node:
+			    node = node.getOrCreatePath(currentPath);
+			}
+			previousPath = currentPath;
+		}
+		
+		// once we're done we still have the last hierarchy line contained in 'node',
+		// eg /x, /x/y, /x/y/z
+		// and that one we must now append to the diffcache entry:
+		while(node!=null) {
+            entry.append(node.getPath(), getChanges(node));
+			deDuplicatedCnt++;
+			node = node.parent;
+		}
+		
+		// and finally: mark the diffcache entry as 'done':
+        entry.done();
+        LOG.debug("applyTo: done. totalCnt: {}, deDuplicatedCnt: {}", totalCnt, deDuplicatedCnt);
+    }
+    
     /**
-     * Gets a document with external changes within the given revision range.
-     * The two revisions must have the same clusterId.
+     * Reads all external changes between the two given revisions (with the same clusterId)
+     * from the journal and appends the paths therein to the provided sorter.
      *
+     * @param sorter the StringSort to which all externally changed paths between
+     * the provided revisions will be added
      * @param from the lower bound of the revision range (exclusive).
      * @param to the upper bound of the revision range (inclusive).
      * @param store the document store to query.
-     * @return a document with the external changes between {@code from} and
-     *          {@code to}.
+     * @throws IOException 
      */
-    static JournalEntry getChanges(@Nonnull Revision from,
-                                   @Nonnull Revision to,
-                                   @Nonnull DocumentStore store) {
+    static void fillExternalChanges(@Nonnull StringSort sorter,
+                                    @Nonnull Revision from,
+                                    @Nonnull Revision to,
+                                    @Nonnull DocumentStore store) throws IOException {
         checkArgument(checkNotNull(from).getClusterId() == checkNotNull(to).getClusterId());
-
+        
         // to is inclusive, but DocumentStore.query() toKey is exclusive
+        final String inclusiveToId = asId(to);
         to = new Revision(to.getTimestamp(), to.getCounter() + 1,
                 to.getClusterId(), to.isBranch());
 
-        JournalEntry doc = JOURNAL.newDocument(store);
-        for (JournalEntry d : store.query(JOURNAL, asId(from), asId(to), Integer.MAX_VALUE)) {
-            doc.apply(d);
+        // read in chunks to support very large sets of changes between subsequent background reads
+        // to do this, provide a (TODO eventually configurable) limit for the number of entries to be returned per query
+        // if the number of elements returned by the query is exactly the provided limit, then
+        // loop and do subsequent queries
+        final String toId = asId(to);
+        String fromId = asId(from);
+        while(true) {
+        	if (fromId.equals(inclusiveToId)) {
+        		// avoid query if from and to are off by just 1 counter (which we do due to exclusiveness of query borders)
+        		// as in this case the query will always be empty anyway - so avoid doing the query in the first place
+        		break;
+        	}
+			List<JournalEntry> partialResult = store.query(JOURNAL, fromId, toId, READ_CHUNK_SIZE);
+			if (partialResult==null) {
+				break;
+			}
+			for(JournalEntry d: partialResult) {
+				d.addTo(sorter);
+			}
+			if (partialResult.size()<READ_CHUNK_SIZE) {
+				break;
+			}
+			// otherwise set 'fromId' to the last entry just processed
+			// that works fine as the query is non-inclusive (ie does not include the from which we'd otherwise double-process)
+			fromId = partialResult.get(partialResult.size()-1).getId();
         }
-        return doc;
+    }
+
+    long getRevisionTimestamp() {
+        final String[] parts = getId().split("_");
+        return Long.parseLong(parts[1]);
     }
 
     void modified(String path) {
@@ -156,43 +281,20 @@ public final class JournalEntry extends Document {
         }
         return op;
     }
-
-    /**
-     * Applies the changes of the {@code other} document on top of this
-     * document.
-     *
-     * @param other the other document with external changes.
-     */
-    void apply(JournalEntry other) {
+    
+    void addTo(final StringSort sort) throws IOException {
         TreeNode n = getChanges();
-        n.apply(other.getChanges());
-        for (JournalEntry e : other.getBranchCommits()) {
-            n.apply(e.getChanges());
-        }
-    }
-
-    /**
-     * Applies the changes of this document to the diff cache.
-     *
-     * @param diffCache the diff cache.
-     * @param from the lower bound revision of this change set.
-     * @param to the upper bound revision of this change set.
-     */
-    void applyTo(@Nonnull DiffCache diffCache,
-                 @Nonnull Revision from,
-                 @Nonnull Revision to) {
-        final DiffCache.Entry entry = checkNotNull(diffCache).newEntry(from, to);
-        TraversingVisitor visitor = new TraversingVisitor() {
+        TraversingVisitor v = new TraversingVisitor() {
+            
             @Override
-            public void node(TreeNode node, String path) {
-                entry.append(path, getChanges(node));
+            public void node(TreeNode node, String path) throws IOException {
+                sort.add(path);
             }
         };
-        getChanges().accept(visitor, "/");
+		n.accept(v, "/");
         for (JournalEntry e : getBranchCommits()) {
-            e.getChanges().accept(visitor, "/");
+            e.getChanges().accept(v, "/");
         }
-        entry.done();
     }
 
     /**
@@ -209,8 +311,9 @@ public final class JournalEntry extends Document {
                 JournalEntry d = store.find(JOURNAL, id);
                 if (d == null) {
                     throw new IllegalStateException(
-                            "Missing external change for revision: " + id);
+                            "Missing external change for branch revision: " + id);
                 }
+                //TODO: could this also be a problem with very large number of branches ???
                 commits.add(d);
             }
         }
@@ -219,7 +322,7 @@ public final class JournalEntry extends Document {
 
     //-----------------------------< internal >---------------------------------
 
-    private String getChanges(TreeNode node) {
+    private static String getChanges(TreeNode node) {
         JsopBuilder builder = new JsopBuilder();
         for (String name : node.keySet()) {
             builder.tag('^');
@@ -229,7 +332,7 @@ public final class JournalEntry extends Document {
         return builder.toString();
     }
 
-    private static String asId(@Nonnull Revision revision) {
+    static String asId(@Nonnull Revision revision) {
         checkNotNull(revision);
         String s = String.format(REVISION_FORMAT, revision.getClusterId(), revision.getTimestamp(), revision.getCounter());
         if (revision.isBranch()) {
@@ -253,7 +356,7 @@ public final class JournalEntry extends Document {
     @Nonnull
     private TreeNode getChanges() {
         if (changes == null) {
-            TreeNode node = new TreeNode();
+            TreeNode node = new TreeNode(null, "");
             String c = (String) get(CHANGES);
             if (c != null) {
                 node.parse(new JsopTokenizer(c));
@@ -267,10 +370,64 @@ public final class JournalEntry extends Document {
 
         private final Map<String, TreeNode> children = Maps.newHashMap();
 
-        void apply(TreeNode node) {
-            for (Map.Entry<String, TreeNode> entry : node.children.entrySet()) {
-                getOrCreate(entry.getKey()).apply(entry.getValue());
+        private final String path;
+        private final TreeNode parent;
+        
+        TreeNode(TreeNode parent, String name) {
+            if (name.contains("/")) {
+                throw new IllegalArgumentException("name must not contain /: "+name);
             }
+            this.parent = parent;
+            if (parent==null) {
+                this.path = "/";
+            } else if (parent.parent==null) {
+                this.path = "/" + name;
+            } else {
+                this.path = parent.path + "/" + name;
+            }
+        }
+        
+        public TreeNode getOrCreatePath(String path) {
+            if (path.equals(this.path)) {
+                // then path denotes the same as myself, hence return myself
+                return this;
+            }
+            if (!path.startsWith(this.path)) {
+                // this must never happen
+                throw new IllegalStateException("path not child of myself. path: "+path+", myself: "+this.path);
+            }
+            String sub = this.path.equals("/") ? path.substring(1) : path.substring(this.path.length()+1);
+            String[] parts = sub.split("/");
+            TreeNode n = this;
+            for (int i = 0; i < parts.length; i++) {
+                if (parts[i]!=null && parts[i].length()>0) {
+                    n = n.getOrCreate(parts[i]);
+                }
+            }
+            return n;
+        }
+
+        public boolean isParentOf(String path) {
+            if (this.path.equals("/")) {
+                // root is parent of everything
+                return true;
+            }
+            if (!path.startsWith(this.path+"/")) {
+                // then I'm not parent of that path
+                return false;
+            }
+            final String sub = path.substring(this.path.length()+1);
+            if (sub.indexOf("/", 1)!=-1) {
+                // if the 'sub' part contains a / then 
+                // it is not a direct child of myself,
+                // so I'm a grand-parent but not a direct-parent
+                return false;
+            }
+            return true;
+        }
+
+        private String getPath() {
+            return path;
         }
 
         void parse(JsopReader reader) {
@@ -303,7 +460,7 @@ public final class JournalEntry extends Document {
             return children.get(name);
         }
 
-        void accept(TraversingVisitor visitor, String path) {
+        void accept(TraversingVisitor visitor, String path) throws IOException {
             visitor.node(this, path);
             for (Map.Entry<String, TreeNode> entry : children.entrySet()) {
                 entry.getValue().accept(visitor, concat(path, entry.getKey()));
@@ -322,7 +479,7 @@ public final class JournalEntry extends Document {
         private TreeNode getOrCreate(String name) {
             TreeNode c = children.get(name);
             if (c == null) {
-                c = new TreeNode();
+                c = new TreeNode(this, name);
                 children.put(name, c);
             }
             return c;
@@ -331,6 +488,7 @@ public final class JournalEntry extends Document {
 
     private interface TraversingVisitor {
 
-        void node(TreeNode node, String path);
+        void node(TreeNode node, String path) throws IOException;
     }
+
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalGarbageCollector.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalGarbageCollector.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.jackrabbit.oak.plugins.document;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+
+/**
+ * The JournalGarbageCollector can clean up JournalEntries that are
+ * older than a particular age.
+ * <p>
+ * It would typically be invoked in conjunction with the VersionGarbageCollector
+ * but must not be confused with that one - 'journal' refers to the separate
+ * collection that contains changed paths per background writes used for 
+ * observation.
+ */
+public class JournalGarbageCollector {
+
+	//copied from VersionGarbageCollector:
+    private static final int DELETE_BATCH_SIZE = 450;
+    
+    private final DocumentStore ds;
+
+    private static final Logger log = LoggerFactory.getLogger(JournalGarbageCollector.class);
+
+    public JournalGarbageCollector(DocumentNodeStore nodeStore) {
+        this.ds = nodeStore.getDocumentStore();
+    }
+
+    public void gc(long maxRevisionAge, TimeUnit unit) throws IOException {
+        long maxRevisionAgeInMillis = unit.toMillis(maxRevisionAge);
+        log.info("gc: Journal garbage collection starts with maxAge: {} ms.", maxRevisionAgeInMillis);
+        Stopwatch sw = Stopwatch.createStarted();
+        
+        // the journal has ids of the following format:
+        // 1-0000014db9aaf710-00000001
+        // whereas the first number is the cluster node id.
+        // now, this format prevents from doing a generic
+        // query to get all 'old' entries, as the documentstore
+        // can only query for a sequential list of entries.
+        // (and the cluster node id here partitions the set
+        // of entries that we have to delete)
+        // To account for that, we simply iterate over all 
+        // cluster node ids and clean them up individually.
+        // Note that there are possible alternatives, such
+        // as: let each node clean up its own old entries
+        // but the chosen path is also quite simple: it can
+        // be started on any instance - but best on only one.
+        // if it's run on multiple concurrently, then they
+        // will compete at deletion, which is not optimal
+        // due to performance, but does not harm.
+        
+        // 1. get the list of cluster node ids
+        final List<ClusterNodeInfoDocument> clusterNodeInfos = ClusterNodeInfoDocument.all(ds);
+        int numDeleted = 0;
+        for (Iterator<ClusterNodeInfoDocument> it = clusterNodeInfos.iterator(); it
+				.hasNext();) {
+        	// current algorithm is to simply look at all cluster nodes
+        	// irrespective of whether they are active or inactive etc.
+        	// this could be optimized for inactive ones: at some point, all
+        	// journal entries of inactive ones would have been cleaned up
+        	// and at that point we could stop including those long-time-inactive ones.
+        	// that 'long time' aspect would have to be tracked though, to be sure
+        	// we don't leave garbage.
+        	// so simpler is to quickly do a query even for long-time inactive ones
+			final ClusterNodeInfoDocument clusterNodeInfoDocument = it.next();
+			final int clusterNodeId = clusterNodeInfoDocument.getClusterId();
+			
+			// 2. iterate over that list and do a query with
+			//    a limit of 'batch size'
+			boolean branch = false;
+			long startPointer = 0;
+			while(true) {
+				String fromKey = JournalEntry.asId(new Revision(startPointer, 0, clusterNodeId, branch));
+				String toKey = JournalEntry.asId(new Revision(
+						System.currentTimeMillis() - maxRevisionAgeInMillis, Integer.MAX_VALUE, clusterNodeId, branch));
+				int limit = DELETE_BATCH_SIZE;
+				List<JournalEntry> deletionBatch = ds.query(Collection.JOURNAL, fromKey, toKey, limit);
+				if (deletionBatch.size()>0) {
+					ds.remove(Collection.JOURNAL, asKeys(deletionBatch));
+					numDeleted+=deletionBatch.size();
+				}
+				if (deletionBatch.size()<limit) {
+					if (!branch) {
+						// do the same for branches:
+						// this will start at the beginning again with branch set to true
+						// and eventually finish too
+						startPointer = 0;
+						branch = true;
+						continue;
+					}
+					break;
+				}
+				startPointer = deletionBatch.get(deletionBatch.size()-1).getRevisionTimestamp();
+			}
+		}
+        
+        sw.stop();
+        
+        log.info("gc: Journal garbage collected in {}. Deleted {}.", sw, numDeleted);
+    }
+
+	private List<String> asKeys(List<JournalEntry> deletionBatch) {
+		final List<String> keys = new ArrayList<String>(deletionBatch.size());
+		for (JournalEntry e: deletionBatch) {
+			keys.add(e.getId());
+		}
+		return keys;
+	}
+
+}

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalGarbageCollector.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalGarbageCollector.java
@@ -19,7 +19,6 @@
 
 package org.apache.jackrabbit.oak.plugins.document;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -52,7 +51,13 @@ public class JournalGarbageCollector {
         this.ds = nodeStore.getDocumentStore();
     }
 
-    public void gc(long maxRevisionAge, TimeUnit unit) throws IOException {
+    /**
+     * Deletes entries in the journal that are older than the given maxRevisionAge.
+     * @param maxRevisionAge entries older than this age will be removed
+     * @param unit the timeunit for maxRevisionAge
+     * @return the number of entries that have been removed
+     */
+    public int gc(long maxRevisionAge, TimeUnit unit) {
         long maxRevisionAgeInMillis = unit.toMillis(maxRevisionAge);
         if (log.isDebugEnabled()) {
             log.debug("gc: Journal garbage collection starts with maxAge: {} min.", TimeUnit.MILLISECONDS.toMinutes(maxRevisionAgeInMillis));
@@ -125,6 +130,7 @@ public class JournalGarbageCollector {
         sw.stop();
         
         log.info("gc: Journal garbage collection took {}, deleted {} entries that were older than {} min.", sw, numDeleted, TimeUnit.MILLISECONDS.toMinutes(maxRevisionAgeInMillis));
+        return numDeleted;
     }
 
 	private List<String> asKeys(List<JournalEntry> deletionBatch) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalGarbageCollector.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalGarbageCollector.java
@@ -54,7 +54,9 @@ public class JournalGarbageCollector {
 
     public void gc(long maxRevisionAge, TimeUnit unit) throws IOException {
         long maxRevisionAgeInMillis = unit.toMillis(maxRevisionAge);
-        log.info("gc: Journal garbage collection starts with maxAge: {} ms.", maxRevisionAgeInMillis);
+        if (log.isDebugEnabled()) {
+            log.debug("gc: Journal garbage collection starts with maxAge: {} min.", TimeUnit.MILLISECONDS.toMinutes(maxRevisionAgeInMillis));
+        }
         Stopwatch sw = Stopwatch.createStarted();
         
         // the journal has ids of the following format:
@@ -122,7 +124,7 @@ public class JournalGarbageCollector {
         
         sw.stop();
         
-        log.info("gc: Journal garbage collected in {}. Deleted {}.", sw, numDeleted);
+        log.info("gc: Journal garbage collection took {}, deleted {} entries that were older than {} min.", sw, numDeleted, TimeUnit.MILLISECONDS.toMinutes(maxRevisionAgeInMillis));
     }
 
 	private List<String> asKeys(List<JournalEntry> deletionBatch) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -215,31 +215,35 @@ public class LastRevRecoveryAgent {
     		// as to whether the recovered lastRev has already been
     		// written to the journal.
             unsaved.persist(nodeStore, new UnsavedModifications.Snapshot() {
-				
-				@Override
-				public void acquiring() {
-					final String id = JournalEntry.asId(lastRootRev);
-					final JournalEntry existingEntry = docStore.find(Collection.JOURNAL, id);
-					if (existingEntry!=null) {
-						// then the journal entry was already written - as can happen if
-						// someone else (or the original instance itself) wrote the
-						// journal entry, then died.
-						// in this case, don't write it again.
-						// hence: nothing to be done here. return.
-						return;
-					}
-					
-					if (lastRootRev==null) {
-						// in this case there was no update done on the root
-						// so we do not have to update the journal as well
-						return;
-					}
-					
-					// otherwise store a new journal entry now
-					docStore.create(JOURNAL,
-	                        singletonList(changes.asUpdateOp(lastRootRev)));
-				}
-			}, new ReentrantLock());
+
+                @Override
+                public void acquiring() {
+                    if (lastRootRev == null) {
+                        // this should never happen - when unsaved has no changes
+                        // that is reflected in the 'map' to be empty - in that
+                        // case 'persist()' quits early and never calls
+                        // acquiring() here.
+                        //
+                        // but even if it would occur - if we have no lastRootRev
+                        // then we cannot and probably don't have to persist anything
+                        return;
+                    }
+
+                    final String id = JournalEntry.asId(lastRootRev); // lastRootRev never null at this point
+                    final JournalEntry existingEntry = docStore.find(Collection.JOURNAL, id);
+                    if (existingEntry != null) {
+                        // then the journal entry was already written - as can happen if
+                        // someone else (or the original instance itself) wrote the
+                        // journal entry, then died.
+                        // in this case, don't write it again.
+                        // hence: nothing to be done here. return.
+                        return;
+                    }
+
+                    // otherwise store a new journal entry now
+                    docStore.create(JOURNAL, singletonList(changes.asUpdateOp(lastRootRev)));
+                }
+            }, new ReentrantLock());
 
             log.info("Updated lastRev of [{}] documents while performing lastRev recovery for " +
                     "cluster node [{}]: {}", size, clusterId, updates);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -22,6 +22,8 @@ package org.apache.jackrabbit.oak.plugins.document;
 import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.mergeSorted;
+import static java.util.Collections.singletonList;
+import static org.apache.jackrabbit.oak.plugins.document.Collection.JOURNAL;
 import static org.apache.jackrabbit.oak.plugins.document.UnsavedModifications.Snapshot.IGNORE;
 
 import java.util.Iterator;
@@ -138,6 +140,8 @@ public class LastRevRecoveryAgent {
 
         //Map of known last rev of checked paths
         Map<String, Revision> knownLastRevs = MapFactory.getInstance().create();
+		final DocumentStore docStore = nodeStore.getDocumentStore();
+        final JournalEntry changes = JOURNAL.newDocument(docStore);
 
         long count = 0;
         while (suspects.hasNext()) {
@@ -166,6 +170,7 @@ public class LastRevRecoveryAgent {
             //2. Update lastRev for parent paths aka rollup
             if (lastRevForParents != null) {
                 String path = doc.getPath();
+                changes.modified(path); // track all changes
                 while (true) {
                     if (PathUtils.denotesRoot(path)) {
                         break;
@@ -188,6 +193,9 @@ public class LastRevRecoveryAgent {
                 unsaved.put(parentPath, calcLastRev);
             }
         }
+        
+        // take the root's lastRev
+        final Revision lastRootRev = unsaved.get("/");
 
         //Note the size before persist as persist operation
         //would empty the internal state
@@ -201,7 +209,37 @@ public class LastRevRecoveryAgent {
             //UnsavedModifications is designed to be used in concurrent
             //access mode. For recovery case there is no concurrent access
             //involve so just pass a new lock instance
-            unsaved.persist(nodeStore, IGNORE, new ReentrantLock());
+        	
+    		// the lock uses to do the persisting is a plain reentrant lock
+    		// thus it doesn't matter, where exactly the check is done
+    		// as to whether the recovered lastRev has already been
+    		// written to the journal.
+            unsaved.persist(nodeStore, new UnsavedModifications.Snapshot() {
+				
+				@Override
+				public void acquiring() {
+					final String id = JournalEntry.asId(lastRootRev);
+					final JournalEntry existingEntry = docStore.find(Collection.JOURNAL, id);
+					if (existingEntry!=null) {
+						// then the journal entry was already written - as can happen if
+						// someone else (or the original instance itself) wrote the
+						// journal entry, then died.
+						// in this case, don't write it again.
+						// hence: nothing to be done here. return.
+						return;
+					}
+					
+					if (lastRootRev==null) {
+						// in this case there was no update done on the root
+						// so we do not have to update the journal as well
+						return;
+					}
+					
+					// otherwise store a new journal entry now
+					docStore.create(JOURNAL,
+	                        singletonList(changes.asUpdateOp(lastRootRev)));
+				}
+			}, new ReentrantLock());
 
             log.info("Updated lastRev of [{}] documents while performing lastRev recovery for " +
                     "cluster node [{}]: {}", size, clusterId, updates);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/LocalDiffCache.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/LocalDiffCache.java
@@ -73,7 +73,8 @@ public class LocalDiffCache implements DiffCache {
     @Nonnull
     @Override
     public Entry newEntry(final @Nonnull Revision from,
-                          final @Nonnull Revision to) {
+                          final @Nonnull Revision to,
+                          boolean local /*ignored*/) {
         return new Entry() {
             private final Map<String, String> changesPerPath = Maps.newHashMap();
             private int size;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/MemoryDiffCache.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/MemoryDiffCache.java
@@ -80,7 +80,8 @@ public class MemoryDiffCache implements DiffCache {
     @Nonnull
     @Override
     public Entry newEntry(@Nonnull Revision from,
-                          @Nonnull Revision to) {
+                          @Nonnull Revision to,
+                          boolean local /*ignored*/) {
         return new MemoryEntry(from, to);
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/TieredDiffCache.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/TieredDiffCache.java
@@ -51,7 +51,8 @@ class TieredDiffCache implements DiffCache {
     }
 
     /**
-     * Creates a new entry in the {@link LocalDiffCache} only!
+     * Creates a new entry in the {@link LocalDiffCache} for local changes
+     * and {@link MemoryDiffCache} for external changes
      *
      * @param from the from revision.
      * @param to the to revision.
@@ -59,8 +60,12 @@ class TieredDiffCache implements DiffCache {
      */
     @Nonnull
     @Override
-    public Entry newEntry(@Nonnull Revision from, @Nonnull Revision to) {
-        return localCache.newEntry(from, to);
+    public Entry newEntry(@Nonnull Revision from, @Nonnull Revision to, boolean local) {
+    	if (local) {
+    		return localCache.newEntry(from, to, true);
+    	} else {
+    		return memoryCache.newEntry(from, to, false);
+    	}
     }
 
     @Nonnull

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDiffCache.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDiffCache.java
@@ -91,7 +91,7 @@ public class MongoDiffCache extends MemoryDiffCache {
             if (changes == null && loader != null) {
                 changes = loader.call();
                 // put into memory cache
-                super.newEntry(from, to).append(path, changes);
+                super.newEntry(from, to, false).append(path, changes);
             }
             return changes;
         } finally {
@@ -102,7 +102,8 @@ public class MongoDiffCache extends MemoryDiffCache {
     @Nonnull
     @Override
     public Entry newEntry(@Nonnull final Revision from,
-                          @Nonnull final Revision to) {
+                          @Nonnull final Revision to,
+                          boolean local /*ignored*/) {
         return new MemoryEntry(from, to) {
 
             private Diff commit = new Diff(from, to);
@@ -172,7 +173,7 @@ public class MongoDiffCache extends MemoryDiffCache {
                 // diff is complete
                 LOG.debug("Built diff from {} commits", numCommits);
                 // apply to diff cache and serve later requests from cache
-                d.applyToEntry(super.newEntry(from, to)).done();
+                d.applyToEntry(super.newEntry(from, to, false)).done();
                 // return changes
                 return d.getChanges(path);
             }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/AmnesiaDiffCache.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/AmnesiaDiffCache.java
@@ -47,7 +47,7 @@ class AmnesiaDiffCache implements DiffCache {
 
     @Nonnull
     @Override
-    public Entry newEntry(@Nonnull Revision from, @Nonnull Revision to) {
+    public Entry newEntry(@Nonnull Revision from, @Nonnull Revision to, boolean local) {
         return new Entry() {
             @Override
             public void append(@Nonnull String path, @Nonnull String changes) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/CountingDocumentStore.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/CountingDocumentStore.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.jackrabbit.oak.cache.CacheStats;
+import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Condition;
+import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Key;
+import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
+
+public class CountingDocumentStore implements DocumentStore {
+	
+	private DocumentStore delegate;
+	
+	//TODO: remove mec
+	boolean printStacks;
+	
+	class Stats {
+		
+		private int numFindCalls;
+		private int numQueryCalls;
+		private int numRemoveCalls;
+		private int numCreateOrUpdateCalls;
+		
+	}
+	
+	private Map<Collection, Stats> collectionStats = new HashMap<Collection, Stats>();
+
+	public CountingDocumentStore(DocumentStore delegate) {
+		this.delegate = delegate;
+	}
+	
+	public void resetCounters() {
+		collectionStats.clear();
+	}
+
+	public int getNumFindCalls(Collection collection) {
+		return getStats(collection).numFindCalls;
+	}
+	
+	public int getNumQueryCalls(Collection collection) {
+		return getStats(collection).numQueryCalls;
+	}
+	
+	public int getNumRemoveCalls(Collection collection) {
+		return getStats(collection).numRemoveCalls;
+	}
+	
+	public int getNumCreateOrUpdateCalls(Collection collection) {
+		return getStats(collection).numCreateOrUpdateCalls;
+	}
+	
+	private Stats getStats(Collection collection) {
+		if (!collectionStats.containsKey(collection)) {
+			Stats s = new Stats();
+			collectionStats.put(collection, s);
+			return s;
+		} else {
+			return collectionStats.get(collection);
+		}
+	}
+	
+	@Override
+	public <T extends Document> T find(Collection<T> collection, String key) {
+		getStats(collection).numFindCalls++;
+		if (printStacks) {
+			new Exception("find ["+getStats(collection).numFindCalls+"] ("+collection+") "+key).printStackTrace();
+		}
+		return delegate.find(collection, key);
+	}
+
+	@Override
+	public <T extends Document> T find(Collection<T> collection, String key,
+			int maxCacheAge) {
+		getStats(collection).numFindCalls++;
+		if (printStacks) {
+			new Exception("find ["+getStats(collection).numFindCalls+"] ("+collection+") "+key+" [max: "+maxCacheAge+"]").printStackTrace();
+		}
+		return delegate.find(collection, key, maxCacheAge);
+	}
+
+	@Override
+	public <T extends Document> List<T> query(Collection<T> collection,
+			String fromKey, String toKey, int limit) {
+		getStats(collection).numQueryCalls++;
+		if (printStacks) {
+			new Exception("query1 ["+getStats(collection).numQueryCalls+"] ("+collection+") "+fromKey+", to "+toKey+". limit "+limit).printStackTrace();
+		}
+		return delegate.query(collection, fromKey, toKey, limit);
+	}
+
+	@Override
+	public <T extends Document> List<T> query(Collection<T> collection,
+			String fromKey, String toKey, String indexedProperty,
+			long startValue, int limit) {
+		getStats(collection).numQueryCalls++;
+		if (printStacks) {
+			new Exception("query2 ["+getStats(collection).numQueryCalls+"] ("+collection+") "+fromKey+", to "+toKey+". limit "+limit).printStackTrace();
+		}
+		return delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit);
+	}
+
+	@Override
+	public <T extends Document> void remove(Collection<T> collection, String key) {
+		getStats(collection).numRemoveCalls++;
+		delegate.remove(collection, key);
+	}
+
+	@Override
+	public <T extends Document> void remove(Collection<T> collection,
+			List<String> keys) {
+		getStats(collection).numRemoveCalls++;
+		delegate.remove(collection, keys);
+	}
+
+	@Override
+	public <T extends Document> int remove(Collection<T> collection,
+			Map<String, Map<Key, Condition>> toRemove) {
+		getStats(collection).numRemoveCalls++;
+		return delegate.remove(collection, toRemove);
+	}
+
+	@Override
+	public <T extends Document> boolean create(Collection<T> collection,
+			List<UpdateOp> updateOps) {
+		getStats(collection).numCreateOrUpdateCalls++;
+		return delegate.create(collection, updateOps);
+	}
+
+	@Override
+	public <T extends Document> void update(Collection<T> collection,
+			List<String> keys, UpdateOp updateOp) {
+		getStats(collection).numCreateOrUpdateCalls++;
+		delegate.update(collection, keys, updateOp);
+	}
+
+	@Override
+	public <T extends Document> T createOrUpdate(Collection<T> collection,
+			UpdateOp update) {
+		getStats(collection).numCreateOrUpdateCalls++;
+		return delegate.createOrUpdate(collection, update);
+	}
+
+	@Override
+	public <T extends Document> T findAndUpdate(Collection<T> collection,
+			UpdateOp update) {
+		getStats(collection).numCreateOrUpdateCalls++;
+		return delegate.findAndUpdate(collection, update);
+	}
+
+	@Override
+	public CacheInvalidationStats invalidateCache() {
+		return delegate.invalidateCache();
+	}
+
+	@Override
+	public <T extends Document> void invalidateCache(Collection<T> collection,
+			String key) {
+		delegate.invalidateCache(collection, key);
+	}
+
+	@Override
+	public void dispose() {
+		delegate.dispose();
+	}
+
+	@Override
+	public <T extends Document> T getIfCached(Collection<T> collection,
+			String key) {
+		return delegate.getIfCached(collection, key);
+	}
+
+	@Override
+	public void setReadWriteMode(String readWriteMode) {
+		delegate.setReadWriteMode(readWriteMode);
+	}
+
+	@Override
+	public CacheStats getCacheStats() {
+		return delegate.getCacheStats();
+	}
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return delegate.getMetadata();
+	}
+
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/CountingTieredDiffCache.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/CountingTieredDiffCache.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+public class CountingTieredDiffCache extends TieredDiffCache {
+
+	class CountingLoader implements Loader {
+
+		private Loader delegate;
+
+		CountingLoader(Loader delegate) {
+			this.delegate = delegate;
+		}
+		
+		@Override
+		public String call() {
+			incLoadCount();
+			return delegate.call();
+		}
+		
+	}
+
+	private int loadCount;
+	
+	public CountingTieredDiffCache(DocumentMK.Builder builder) {
+    	super(builder);
+    }
+	
+	private void incLoadCount() {
+		loadCount++;		
+	}
+	
+	public int getLoadCount() {
+		return loadCount;
+	}
+	
+	public void resetLoadCounter() {
+		loadCount = 0;
+	}
+
+	@Override
+	public String getChanges(Revision from, Revision to, String path,
+			Loader loader) {
+		return super.getChanges(from, to, path, new CountingLoader(loader));
+	}
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
@@ -1657,7 +1657,7 @@ public class DocumentNodeStoreTest {
         merge(ns, builder);
         Revision to = ns.getHeadRevision();
 
-        DiffCache.Entry entry = ns.getDiffCache().newEntry(from, to);
+        DiffCache.Entry entry = ns.getDiffCache().newEntry(from, to, true);
         entry.append("/", "-\"foo\"");
         entry.done();
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/JournalTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/JournalTest.java
@@ -385,6 +385,13 @@ public class JournalTest {
         assertJournalEntries(ds1, "{}", change1); // unchanged
         String change2b = "{\"x\":{\"y\":{\"z\":{}}}}";
         assertJournalEntries(ds2, "{}", change2, change2b);
+        
+        // just some no-ops:
+        recovery.recover(c2Id);
+        List<NodeDocument> emptyList = new LinkedList<NodeDocument>();
+        recovery.recover(emptyList.iterator(), c2Id);
+        assertJournalEntries(ds1, "{}", change1); // unchanged
+        assertJournalEntries(ds2, "{}", change2, change2b);
     }
 
     void assertJournalEntries(DocumentNodeStore ds, String... expectedChanges) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/JournalTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/JournalTest.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
+import org.apache.jackrabbit.oak.spi.blob.BlobStore;
+import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Observer;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStateDiff;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.mongodb.DB;
+
+public class JournalTest {
+
+//    private static final boolean MONGO_DB = false;
+    private static final boolean MONGO_DB = true;
+    
+    private TestBuilder builder;
+
+    private MemoryDocumentStore ds;
+    private MemoryBlobStore bs;
+
+    private List<DocumentMK> mks = Lists.newArrayList();
+
+    class DiffingObserver implements Observer, Runnable, NodeStateDiff {
+
+        final List<DocumentNodeState> incomingRootStates1 = Lists.newArrayList();
+        final List<DocumentNodeState> diffedRootStates1 = Lists.newArrayList();
+        
+        DocumentNodeState oldRoot = null;
+        
+        DiffingObserver(boolean startInBackground) {
+            if (startInBackground) {
+                // start the diffing in the background - so as to not
+                // interfere with the contentChanged call
+                Thread th = new Thread(this);
+                th.setDaemon(true);
+                th.start();
+            }
+        }
+
+        public void clear() {
+            synchronized(incomingRootStates1) {
+                incomingRootStates1.clear();
+                diffedRootStates1.clear();
+            }
+        }
+        
+        @Override
+        public void contentChanged(NodeState root, CommitInfo info) {
+            synchronized(incomingRootStates1) {
+                incomingRootStates1.add((DocumentNodeState) root);
+                incomingRootStates1.notifyAll();
+            }
+        }
+        
+        public void processAll() {
+            while(processOne()) {
+                // continue
+            }
+        }
+
+        public boolean processOne() {
+            DocumentNodeState newRoot;
+            synchronized(incomingRootStates1) {
+                if (incomingRootStates1.size()==0) {
+                    return false;
+                }
+                newRoot = incomingRootStates1.remove(0);
+            }
+            if (oldRoot!=null) {
+                newRoot.compareAgainstBaseState(oldRoot, this);
+            }
+            oldRoot = newRoot;
+            synchronized(incomingRootStates1) {
+                diffedRootStates1.add(newRoot);
+            }
+            return true;
+        }
+        
+        @Override
+        public void run() {
+            while(true) {
+                DocumentNodeState newRoot;
+                synchronized(incomingRootStates1) {
+                    while(incomingRootStates1.size()==0) {
+                        try {
+                            incomingRootStates1.wait();
+                        } catch (InterruptedException e) {
+                            // ignore
+                            continue;
+                        }
+                    }
+                    newRoot = incomingRootStates1.remove(0);
+                }
+                if (oldRoot!=null) {
+                    newRoot.compareAgainstBaseState(oldRoot, this);
+                }
+                oldRoot = newRoot;
+                synchronized(incomingRootStates1) {
+                    diffedRootStates1.add(newRoot);
+                }
+            }
+        }
+
+        @Override
+        public boolean propertyAdded(PropertyState after) {
+            return true;
+        }
+
+        @Override
+        public boolean propertyChanged(PropertyState before, PropertyState after) {
+            return true;
+        }
+
+        @Override
+        public boolean propertyDeleted(PropertyState before) {
+            return true;
+        }
+
+        @Override
+        public boolean childNodeAdded(String name, NodeState after) {
+            return true;
+        }
+
+        @Override
+        public boolean childNodeChanged(String name, NodeState before,
+                NodeState after) {
+            return true;
+        }
+
+        @Override
+        public boolean childNodeDeleted(String name, NodeState before) {
+            return true;
+        }
+
+        public int getTotal() {
+            synchronized(incomingRootStates1) {
+                return incomingRootStates1.size() + diffedRootStates1.size();
+            }
+        }
+        
+    }
+    
+    @Test
+    public void cleanupTest() throws Exception {
+        DocumentMK mk1 = createMK(1, 0);
+        DocumentNodeStore ns1 = mk1.getNodeStore();
+        JournalGarbageCollector gc = new JournalGarbageCollector(ns1);
+        gc.gc(1, TimeUnit.DAYS);
+        gc.gc(6, TimeUnit.HOURS);
+        gc.gc(1, TimeUnit.HOURS);
+        gc.gc(10, TimeUnit.MINUTES);
+        gc.gc(1, TimeUnit.MINUTES);
+    }
+    
+    @Test
+    public void journalTest() throws Exception {
+        DocumentMK mk1 = createMK(1, 0);
+        DocumentNodeStore ns1 = mk1.getNodeStore();
+        CountingDocumentStore countingDocStore1 = builder.actualStore;
+        CountingTieredDiffCache countingDiffCache1 = builder.actualDiffCache;
+
+        DocumentMK mk2 = createMK(2, 0);
+        DocumentNodeStore ns2 = mk2.getNodeStore();
+        CountingDocumentStore countingDocStore2 = builder.actualStore;
+        CountingTieredDiffCache countingDiffCache2 = builder.actualDiffCache;
+
+        final DiffingObserver observer = new DiffingObserver(false);
+        ns1.addObserver(observer);
+        
+        ns1.runBackgroundOperations();
+        ns2.runBackgroundOperations();
+        observer.processAll(); // to make sure we have an 'oldRoot'
+        observer.clear();
+        countingDocStore1.resetCounters();
+        countingDocStore2.resetCounters();
+        countingDocStore1.printStacks = true;
+        countingDiffCache1.resetLoadCounter();
+        countingDiffCache2.resetLoadCounter();
+
+        mk2.commit("/", "+\"regular1\": {}", null, null);
+        mk2.commit("/", "+\"regular2\": {}", null, null);
+        mk2.commit("/", "+\"regular3\": {}", null, null);
+        mk2.commit("/regular2", "+\"regular4\": {}", null, null);
+        // flush to journal
+        ns2.runBackgroundOperations();
+        
+        // nothing notified yet
+        assertEquals(0, observer.getTotal());
+        assertEquals(0, countingDocStore1.getNumFindCalls(Collection.NODES));
+        assertEquals(0, countingDocStore1.getNumQueryCalls(Collection.NODES));
+        assertEquals(0, countingDocStore1.getNumRemoveCalls(Collection.NODES));
+        assertEquals(0, countingDocStore1.getNumCreateOrUpdateCalls(Collection.NODES));
+        assertEquals(0, countingDiffCache1.getLoadCount());
+        
+        // let node 1 read those changes
+        System.err.println("run background ops");
+        ns1.runBackgroundOperations();
+        mk2.commit("/", "+\"regular5\": {}", null, null);
+        ns2.runBackgroundOperations();
+        ns1.runBackgroundOperations();
+        // and let the observer process everything
+        observer.processAll();
+        countingDocStore1.printStacks = false;
+        
+        // now expect 1 entry in rootStates
+        assertEquals(2, observer.getTotal());
+        assertEquals(0, countingDiffCache1.getLoadCount());
+        assertEquals(0, countingDocStore1.getNumRemoveCalls(Collection.NODES));
+        assertEquals(0, countingDocStore1.getNumCreateOrUpdateCalls(Collection.NODES));
+        assertEquals(0, countingDocStore1.getNumQueryCalls(Collection.NODES));
+//        assertEquals(0, countingDocStore1.getNumFindCalls(Collection.NODES));
+    }
+    
+    @Test
+    public void externalBranchChange() throws Exception {
+        DocumentMK mk1 = createMK(1, 0);
+        DocumentNodeStore ns1 = mk1.getNodeStore();
+        DocumentMK mk2 = createMK(2, 0);
+        DocumentNodeStore ns2 = mk2.getNodeStore();
+        
+        ns1.runBackgroundOperations();
+        ns2.runBackgroundOperations();
+
+        mk1.commit("/", "+\"regular1\": {}", null, null);
+        // flush to journal
+        ns1.runBackgroundOperations();
+        mk1.commit("/regular1", "+\"regular1child\": {}", null, null);
+        // flush to journal
+        ns1.runBackgroundOperations();
+        mk1.commit("/", "+\"regular2\": {}", null, null);
+        // flush to journal
+        ns1.runBackgroundOperations();
+        mk1.commit("/", "+\"regular3\": {}", null, null);
+        // flush to journal
+        ns1.runBackgroundOperations();
+        mk1.commit("/", "+\"regular4\": {}", null, null);
+        // flush to journal
+        ns1.runBackgroundOperations();
+        mk1.commit("/", "+\"regular5\": {}", null, null);
+        // flush to journal
+        ns1.runBackgroundOperations();
+        String b1 = mk1.branch(null);
+        b1 = mk1.commit("/", "+\"branchVisible\": {}", b1, null);
+        mk1.merge(b1, null);
+        
+        // to flush the branch commit either dispose of mk1
+        // or run the background operations explicitly 
+        // (as that will propagate the lastRev to the root)
+        ns1.runBackgroundOperations();
+        ns2.runBackgroundOperations();
+        
+        String nodes = mk2.getNodes("/", null, 0, 0, 100, null);
+        assertEquals("{\"branchVisible\":{},\"regular1\":{},\"regular2\":{},\"regular3\":{},\"regular4\":{},\"regular5\":{},\":childNodeCount\":6}", nodes);
+    }
+
+    @Before
+    @After
+    public void clear() {
+        for (DocumentMK mk : mks) {
+            mk.dispose();
+        }
+        mks.clear();
+        if (MONGO_DB) {
+            DB db = MongoUtils.getConnection().getDB();
+            MongoUtils.dropCollections(db);
+        }
+    }
+
+    private final class TestBuilder extends DocumentMK.Builder {
+        private CountingDocumentStore actualStore;
+        private CountingTieredDiffCache actualDiffCache;
+
+        @Override
+        public DocumentStore getDocumentStore() {
+            if (actualStore==null) {
+                actualStore = new CountingDocumentStore(super.getDocumentStore());
+            }
+            return actualStore;
+        }
+        
+        @Override
+        public DiffCache getDiffCache() {
+            if (actualDiffCache==null) {
+                actualDiffCache = new CountingTieredDiffCache(this);
+            }
+            return actualDiffCache;
+        }
+    }
+
+    private DocumentMK createMK(int clusterId, int asyncDelay) {
+        if (MONGO_DB) {
+            DB db = MongoUtils.getConnection(/*"oak-observation"*/).getDB();
+            builder = newDocumentMKBuilder();
+            return register(builder.setMongoDB(db)
+                    .setClusterId(clusterId).setAsyncDelay(asyncDelay).open());
+        } else {
+            if (ds == null) {
+                ds = new MemoryDocumentStore();
+            }
+            if (bs == null) {
+                bs = new MemoryBlobStore();
+            }
+            return createMK(clusterId, asyncDelay, ds, bs);
+        }
+    }
+    
+    private TestBuilder newDocumentMKBuilder() {
+        return new TestBuilder();
+    }
+
+    private DocumentMK createMK(int clusterId, int asyncDelay,
+                             DocumentStore ds, BlobStore bs) {
+        builder = newDocumentMKBuilder();
+        return register(builder.setDocumentStore(ds)
+                .setBlobStore(bs).setClusterId(clusterId)
+                .setAsyncDelay(asyncDelay).open());
+    }
+
+    private DocumentMK register(DocumentMK mk) {
+        mks.add(mk);
+        return mk;
+    }
+
+    private void disposeMK(DocumentMK mk) {
+        mk.dispose();
+        for (int i = 0; i < mks.size(); i++) {
+            if (mks.get(i) == mk) {
+                mks.remove(i);
+            }
+        }
+    }
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/JournalTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/JournalTest.java
@@ -17,29 +17,38 @@
 package org.apache.jackrabbit.oak.plugins.document;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.commit.Observer;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateDiff;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.mongodb.DB;
 
 public class JournalTest {
 
-//    private static final boolean MONGO_DB = false;
-    private static final boolean MONGO_DB = true;
+    private static final boolean MONGO_DB = false;
+//    private static final boolean MONGO_DB = true;
     
     private TestBuilder builder;
 
@@ -170,14 +179,38 @@ public class JournalTest {
     
     @Test
     public void cleanupTest() throws Exception {
-        DocumentMK mk1 = createMK(1, 0);
+        DocumentMK mk1 = createMK(0 /* clusterId: 0 => uses clusterNodes collection */, 0);
         DocumentNodeStore ns1 = mk1.getNodeStore();
+        // make sure we're visible and marked as active
+        ns1.renewClusterIdLease();
         JournalGarbageCollector gc = new JournalGarbageCollector(ns1);
-        gc.gc(1, TimeUnit.DAYS);
-        gc.gc(6, TimeUnit.HOURS);
-        gc.gc(1, TimeUnit.HOURS);
-        gc.gc(10, TimeUnit.MINUTES);
-        gc.gc(1, TimeUnit.MINUTES);
+        // first clean up
+        gc.gc(1, TimeUnit.MILLISECONDS);
+        Thread.sleep(100); // sleep just quickly
+        assertEquals(0, gc.gc(1, TimeUnit.DAYS));
+        assertEquals(0, gc.gc(6, TimeUnit.HOURS));
+        assertEquals(0, gc.gc(1, TimeUnit.HOURS));
+        assertEquals(0, gc.gc(10, TimeUnit.MINUTES));
+        assertEquals(0, gc.gc(1, TimeUnit.MINUTES));
+        assertEquals(0, gc.gc(1, TimeUnit.SECONDS));
+        assertEquals(0, gc.gc(1, TimeUnit.MILLISECONDS));
+        
+        // create some entries that can be deleted thereupon
+        mk1.commit("/", "+\"regular1\": {}", null, null);
+        mk1.commit("/", "+\"regular2\": {}", null, null);
+        mk1.commit("/", "+\"regular3\": {}", null, null);
+        mk1.commit("/regular2", "+\"regular4\": {}", null, null);
+        Thread.sleep(100); // sleep 100millis
+        assertEquals(0, gc.gc(5, TimeUnit.SECONDS));
+        assertEquals(0, gc.gc(1, TimeUnit.MILLISECONDS));
+        ns1.runBackgroundOperations();
+        mk1.commit("/", "+\"regular5\": {}", null, null);
+        ns1.runBackgroundOperations();
+        mk1.commit("/", "+\"regular6\": {}", null, null);
+        ns1.runBackgroundOperations();
+        Thread.sleep(100); // sleep 100millis
+        assertEquals(0, gc.gc(5, TimeUnit.SECONDS));
+        assertEquals(3, gc.gc(1, TimeUnit.MILLISECONDS));
     }
     
     @Test
@@ -279,6 +312,114 @@ public class JournalTest {
         
         String nodes = mk2.getNodes("/", null, 0, 0, 100, null);
         assertEquals("{\"branchVisible\":{},\"regular1\":{},\"regular2\":{},\"regular3\":{},\"regular4\":{},\"regular5\":{},\":childNodeCount\":6}", nodes);
+    }
+    
+    /** Inspired by LastRevRecoveryTest.testRecover() - simplified and extended with journal related asserts **/
+    @Test
+    public void lastRevRecoveryJournalTest() throws Exception {
+        DocumentMK mk1 = createMK(0 /*clusterId via clusterNodes collection*/, 0);
+        DocumentNodeStore ds1 = mk1.getNodeStore();
+        DocumentMK mk2 = createMK(0 /*clusterId via clusterNodes collection*/, 0);
+        DocumentNodeStore ds2 = mk2.getNodeStore();
+        int c2Id = ds2.getClusterId();
+        
+        // should have 1 each with just the root changed
+        assertJournalEntries(ds1, "{}");
+        assertJournalEntries(ds2, "{}");
+        assertEquals(1, countJournalEntries(ds1, 10)); 
+        assertEquals(1, countJournalEntries(ds2, 10));
+        
+        //1. Create base structure /x/y
+        NodeBuilder b1 = ds1.getRoot().builder();
+        b1.child("x").child("y");
+        ds1.merge(b1, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        ds1.runBackgroundOperations();
+
+        //lastRev are persisted directly for new nodes. In case of
+        // updates they are persisted via background jobs
+
+        //1.2 Get last rev populated for root node for ds2
+        ds2.runBackgroundOperations();
+        NodeBuilder b2 = ds2.getRoot().builder();
+        b2.child("x").setProperty("f1","b1");
+        ds2.merge(b2, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        ds2.runBackgroundOperations();
+
+        //2. Add a new node /x/y/z
+        b2 = ds2.getRoot().builder();
+        b2.child("x").child("y").child("z").setProperty("foo", "bar");
+        ds2.merge(b2, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+
+        //Refresh DS1
+        ds1.runBackgroundOperations();
+
+        NodeDocument z1 = getDocument(ds1, "/x/y/z");
+        NodeDocument y1 = getDocument(ds1, "/x/y");
+        NodeDocument x1 = getDocument(ds1, "/x");
+
+        Revision zlastRev2 = z1.getLastRev().get(c2Id);
+        // /x/y/z is a new node and does not have a _lastRev
+        assertNull(zlastRev2);
+        Revision head2 = ds2.getHeadRevision();
+
+        //lastRev should not be updated for C #2
+        assertNull(y1.getLastRev().get(c2Id));
+
+        // besides the former root change, now 1 also has 
+        final String change1 = "{\"x\":{\"y\":{}}}";
+        assertJournalEntries(ds1, "{}", change1);
+        final String change2 = "{\"x\":{}}";
+        assertJournalEntries(ds2, "{}", change2);
+
+        LastRevRecoveryAgent recovery = new LastRevRecoveryAgent(ds1);
+
+        //Do not pass y1 but still y1 should be updated
+        recovery.recover(Iterators.forArray(x1,z1), c2Id);
+
+        //Post recovery the lastRev should be updated for /x/y and /x
+        assertEquals(head2, getDocument(ds1, "/x/y").getLastRev().get(c2Id));
+        assertEquals(head2, getDocument(ds1, "/x").getLastRev().get(c2Id));
+        assertEquals(head2, getDocument(ds1, "/").getLastRev().get(c2Id));
+
+        // now 1 is unchanged, but 2 was recovered now, so has one more:
+        assertJournalEntries(ds1, "{}", change1); // unchanged
+        String change2b = "{\"x\":{\"y\":{\"z\":{}}}}";
+        assertJournalEntries(ds2, "{}", change2, change2b);
+    }
+
+    void assertJournalEntries(DocumentNodeStore ds, String... expectedChanges) {
+        List<String> exp = new LinkedList<String>(Arrays.asList(expectedChanges));
+        for(boolean branch : new Boolean[]{false, true}) {
+            String fromKey = JournalEntry.asId(new Revision(0, 0, ds.getClusterId(), branch));
+            String toKey = JournalEntry.asId(new Revision(System.currentTimeMillis()+1000, 0, ds.getClusterId(), branch));
+            List<JournalEntry> entries = ds.getDocumentStore().query(Collection.JOURNAL, fromKey, toKey, expectedChanges.length+5);
+            if (entries.size()>0) {
+                for (Iterator<JournalEntry> it = entries.iterator(); it.hasNext();) {
+                    JournalEntry journalEntry = it.next();
+                    if (!exp.remove(journalEntry.get("_c"))) {
+                        fail("Found an unexpected change: "+journalEntry.get("_c")+", while all I expected was: "+expectedChanges);
+                    }
+                }
+            }
+        }
+        if (exp.size()>0) {
+            fail("Did not find all expected changes, left over: "+exp+" (from original list which is: "+expectedChanges+")");
+        }
+    }
+
+    int countJournalEntries(DocumentNodeStore ds, int max) {
+        int total = 0;
+        for(boolean branch : new Boolean[]{false, true}) {
+            String fromKey = JournalEntry.asId(new Revision(0, 0, ds.getClusterId(), branch));
+            String toKey = JournalEntry.asId(new Revision(System.currentTimeMillis()+1000, 0, ds.getClusterId(), branch));
+            List<JournalEntry> entries = ds.getDocumentStore().query(Collection.JOURNAL, fromKey, toKey, max);
+            total+=entries.size();
+        }
+        return total;
+    }
+    
+    private NodeDocument getDocument(DocumentNodeStore nodeStore, String path) {
+        return nodeStore.getDocumentStore().find(Collection.NODES, Utils.getIdFromPath(path));
     }
 
     @Before

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDiffCacheTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDiffCacheTest.java
@@ -88,7 +88,7 @@ public class MongoDiffCacheTest {
         
         MongoDiffCache diffCache = new MongoDiffCache(db, 32, new DocumentMK.Builder());
         DiffCache.Entry entry = diffCache.newEntry(
-                new Revision(1, 0, 1), new Revision(2, 0, 1));
+                new Revision(1, 0, 1), new Revision(2, 0, 1), false);
         for (int i = 0; i < 100; i++) {
             for (int j = 0; j < 100; j++) {
                 for (int k = 0; k < 64; k++) {


### PR DESCRIPTION
…n applying changes to diffcache, push changes to memorydiffcache instead of localdiffcache, handle external changes for recoveries, clean up old journal entries.

@mreutegg pls review and apply as applicable,

Thx,
Cheers,
Stefan
